### PR TITLE
Largeish performance improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ module.exports = function(field, tilesize, dimensions, offset) {
 
   return collide
 
+  function ceil(n) {
+    return (n===0) ? 0 : Math.ceil(n)
+  }
+  
   function collide(box, vec, oncollision) {
 
     // collide x, then y - if vector has a nonzero component
@@ -37,9 +41,9 @@ module.exports = function(field, tilesize, dimensions, offset) {
         , i_start = Math.floor(leading / tilesize)
         , i_end = (Math.floor((leading + vec[i_axis]) / tilesize)) + dir
         , j_start = Math.floor(box.base[j_axis] / tilesize)
-        , j_end = Math.ceil(box.max[j_axis] / tilesize)
+        , j_end = ceil(box.max[j_axis] / tilesize)
         , k_start = Math.floor(box.base[k_axis] / tilesize) 
-        , k_end = Math.ceil(box.max[k_axis] / tilesize)
+        , k_end = ceil(box.max[k_axis] / tilesize)
         , done = false
         , edge_vector
         , edge

--- a/index.js
+++ b/index.js
@@ -26,64 +26,63 @@ module.exports = function(field, tilesize, dimensions, offset) {
   }
   
   function collide(box, vec, oncollision) {
-
     // collide x, then y - if vector has a nonzero component
-    if(vec[0] !== 0) collideaxis(0)
-    if(vec[1] !== 0) collideaxis(1)
-    if(vec[2] !== 0) collideaxis(2)
+    if(vec[0] !== 0) collideaxis(0, box, vec, oncollision)
+    if(vec[1] !== 0) collideaxis(1, box, vec, oncollision)
+    if(vec[2] !== 0) collideaxis(2, box, vec, oncollision)
+  }
 
-    function collideaxis(i_axis) {
-      var j_axis = (i_axis + 1) % 3
-        , k_axis = (i_axis + 2) % 3 
-        , posi = vec[i_axis] > 0
-        , leading = box[posi ? 'max' : 'base'][i_axis] 
-        , dir = posi ? 1 : -1
-        , i_start = Math.floor(leading / tilesize)
-        , i_end = (Math.floor((leading + vec[i_axis]) / tilesize)) + dir
-        , j_start = Math.floor(box.base[j_axis] / tilesize)
-        , j_end = ceil(box.max[j_axis] / tilesize)
-        , k_start = Math.floor(box.base[k_axis] / tilesize) 
-        , k_end = ceil(box.max[k_axis] / tilesize)
-        , done = false
-        , edge_vector
-        , edge
-        , tile
+  function collideaxis(i_axis, box, vec, oncollision) {
+    var j_axis = (i_axis + 1) % 3
+      , k_axis = (i_axis + 2) % 3 
+      , posi = vec[i_axis] > 0
+      , leading = box[posi ? 'max' : 'base'][i_axis] 
+      , dir = posi ? 1 : -1
+      , i_start = Math.floor(leading / tilesize)
+      , i_end = (Math.floor((leading + vec[i_axis]) / tilesize)) + dir
+      , j_start = Math.floor(box.base[j_axis] / tilesize)
+      , j_end = ceil(box.max[j_axis] / tilesize)
+      , k_start = Math.floor(box.base[k_axis] / tilesize) 
+      , k_end = ceil(box.max[k_axis] / tilesize)
+      , done = false
+      , edge_vector
+      , edge
+      , tile
 
-      // loop from the current tile coord to the dest tile coord
-      //    -> loop on the opposite axis to get the other candidates
-      //      -> if `oncollision` return `true` we've hit something and
-      //         should break out of the loops entirely.
-      //         NB: `oncollision` is where the client gets the chance
-      //         to modify the `vec` in-flight.
-      // once we're done translate the box to the vec results
+    // loop from the current tile coord to the dest tile coord
+    //    -> loop on the opposite axis to get the other candidates
+    //      -> if `oncollision` return `true` we've hit something and
+    //         should break out of the loops entirely.
+    //         NB: `oncollision` is where the client gets the chance
+    //         to modify the `vec` in-flight.
+    // once we're done translate the box to the vec results
 
-      outer: 
-      for(var i = i_start; i !== i_end; i += dir) {
-        if(i < offset[i_axis] || i >= dimensions[i_axis]) continue
-        for(var j = j_start; j !== j_end; ++j) {
-          if(j < offset[j_axis] || j >= dimensions[j_axis]) continue
-          for(var k = k_start; k !== k_end; ++k) {
-            if(k < offset[k_axis] || k >= dimensions[k_axis]) continue
-            coords[i_axis] = i
-            coords[j_axis] = j
-            coords[k_axis] = k
-            tile = field.apply(field, coords)
+    outer: 
+    for(var i = i_start; i !== i_end; i += dir) {
+      if(i < offset[i_axis] || i >= dimensions[i_axis]) continue
+      for(var j = j_start; j !== j_end; ++j) {
+        if(j < offset[j_axis] || j >= dimensions[j_axis]) continue
+        for(var k = k_start; k !== k_end; ++k) {
+          if(k < offset[k_axis] || k >= dimensions[k_axis]) continue
+          coords[i_axis] = i
+          coords[j_axis] = j
+          coords[k_axis] = k
+          tile = field.apply(field, coords)
 
-            if(tile === undefined) continue
+          if(tile === undefined) continue
 
-            edge = dir > 0 ? i * tilesize : (i + 1) * tilesize
-            edge_vector = edge - leading
+          edge = dir > 0 ? i * tilesize : (i + 1) * tilesize
+          edge_vector = edge - leading
 
-            if(oncollision(i_axis, tile, coords, dir, edge_vector)) {
-              break outer
-            }
-          } 
-        }
+          if(oncollision(i_axis, tile, coords, dir, edge_vector)) {
+            break outer
+          }
+        } 
       }
-
-      coords[0] = coords[1] = coords[2] = 0
-      coords[i_axis] = vec[i_axis]
-      box.translate(coords)
     }
-  }  
+
+    coords[0] = coords[1] = coords[2] = 0
+    coords[i_axis] = vec[i_axis]
+    box.translate(coords)
+  }
 }

--- a/index.js
+++ b/index.js
@@ -57,10 +57,10 @@ module.exports = function(field, tilesize, dimensions, offset) {
       //         to modify the `vec` in-flight.
       // once we're done translate the box to the vec results
 
-      var step = 0
-      for(var i = i_start; !done && i !== i_end; ++step, i += dir) {
+      outer: 
+      for(var i = i_start; i !== i_end; i += dir) {
         if(i < offset[i_axis] || i >= dimensions[i_axis]) continue
-        for(var j = j_start; !done && j !== j_end; ++j) {
+        for(var j = j_start; j !== j_end; ++j) {
           if(j < offset[j_axis] || j >= dimensions[j_axis]) continue
           for(var k = k_start; k !== k_end; ++k) {
             if(k < offset[k_axis] || k >= dimensions[k_axis]) continue
@@ -75,8 +75,7 @@ module.exports = function(field, tilesize, dimensions, offset) {
             edge_vector = edge - leading
 
             if(oncollision(i_axis, tile, coords, dir, edge_vector)) {
-              done = true
-              break
+              break outer
             }
           } 
         }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ module.exports = function(field, tilesize, dimensions, offset) {
   ]
 
   field = typeof field === 'function' ? field : function(x, y, z) {
-    return this[x + y * dimensions[1] + (z * dimensions[1] * dimensions[2])]
+    var i = x + y * dimensions[1] + (z * dimensions[1] * dimensions[2])
+    if (i<0 || i>=this.length) return undefined
+    return this[i]
   }.bind(field) 
 
   var coords
@@ -59,11 +61,8 @@ module.exports = function(field, tilesize, dimensions, offset) {
 
     outer: 
     for(var i = i_start; i !== i_end; i += dir) {
-      if(i < offset[i_axis] || i >= dimensions[i_axis]) continue
       for(var j = j_start; j !== j_end; ++j) {
-        if(j < offset[j_axis] || j >= dimensions[j_axis]) continue
         for(var k = k_start; k !== k_end; ++k) {
-          if(k < offset[k_axis] || k >= dimensions[k_axis]) continue
           coords[i_axis] = i
           coords[j_axis] = j
           coords[k_axis] = k

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = function(field, tilesize, dimensions, offset) {
           coords[i_axis] = i
           coords[j_axis] = j
           coords[k_axis] = k
-          tile = field.apply(field, coords)
+          tile = field(coords[0], coords[1], coords[2])
 
           if(tile === undefined) continue
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collide-3d-tilemap",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "3d tilemap collisions made simple-ish",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi,

This PR wraps up several changes which, all together, improve raw perf by a bit more than 2x in v8. I didn't do detailed tests elsewhere but it's a fair bit faster in firefox as well. The main differences are avoiding `function.apply()` and some refactoring to let v8 optimize the main function.

There are two small breaking changes:
1. Directly calls the passed-in tile query function, rather than using `apply()`. Could break existing user code (though they can easily work around by binding or currying their getter)
2. Removes bounds checks from axis loops. Anybody who's passing in a getter function will need to do this anyway, and for anyone passing in arrays I added a bounds check to the built-in wrapper.

Let me know what you think. In my real-world app these changes take my `physics.tick()` function from 9ms to 2ms, so I think it's worthwhile. But if you'd rather not take breaking changes I'm happy to fork under a new name, either way.

cheers!
